### PR TITLE
Fix form spec error

### DIFF
--- a/test/specs/form.spec.js
+++ b/test/specs/form.spec.js
@@ -7,6 +7,7 @@ describe('auth form', function () {
         FormPage.password.setValue('bar')
         FormPage.submit()
 
+        FormPage.flash.waitForVisible();
         expect(FormPage.flash.getText()).toContain('Your username is invalid!')
     })
 


### PR DESCRIPTION
On slower connections the ⚡️ will take a while (normally the ⚡️ is much faster 😜). 
Added an extra wait like in the next testcase