### PR TITLE
Update ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,8 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
         - name: Checkout
-          uses: actions/checkout@v2
-        - uses: actions/setup-node@v1
+          uses: actions/checkout@v4
+        - uses: actions/setup-node@v3
           with:
             node-version: 18
         - name: Install


### PR DESCRIPTION
Getting warning with the previous actions/checkout and actions/setup-node versions, hence it's good to update with the latest version and documentation changes.